### PR TITLE
feat: Adding ApiPassword support to the config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Note that the ants connect to each other over the public Internet, so you must e
 ```
 {
 	'APIAddr': the api address for the ant to listen on, by default an unused localhost: bind address will be used.
+	'APIAddr': the password to be used for authenticating certain calls to the ant.
 	'RPCAddr': the RPC address for the ant to listen on, by default an unused bind address will be used.
 	'HostAddr': the Host address for the ant to listen on, by default an unused bind address will be used.
 	'SiaDirectory': the data directory to use for this ant, by default a unique directory in `./antfarm-data` will be generated and used.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Note that the ants connect to each other over the public Internet, so you must e
 ```
 {
 	'APIAddr': the api address for the ant to listen on, by default an unused localhost: bind address will be used.
-	'APIAddr': the password to be used for authenticating certain calls to the ant.
+	'APIPassword': the password to be used for authenticating certain calls to the ant.
 	'RPCAddr': the RPC address for the ant to listen on, by default an unused bind address will be used.
 	'HostAddr': the Host address for the ant to listen on, by default an unused bind address will be used.
 	'SiaDirectory': the data directory to use for this ant, by default a unique directory in `./antfarm-data` will be generated and used.

--- a/ant/ant.go
+++ b/ant/ant.go
@@ -18,6 +18,7 @@ type AntConfig struct {
 	HostAddr        string `json:",omitempty"`
 	SiaDirectory    string `json:",omitempty"`
 	Name            string `json:",omitempty"`
+	APIPassword		string `json:",omitempty"`
 	SiadPath        string
 	Jobs            []string
 	DesiredCurrency uint64
@@ -81,7 +82,7 @@ func New(config AntConfig) (*Ant, error) {
 	}
 
 	// Construct the ant's Siad instance
-	siad, err := newSiad(config.SiadPath, config.SiaDirectory, config.APIAddr, config.RPCAddr, config.HostAddr)
+	siad, err := newSiad(config.SiadPath, config.SiaDirectory, config.APIAddr, config.RPCAddr, config.HostAddr, config.APIPassword)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +94,7 @@ func New(config AntConfig) (*Ant, error) {
 		}
 	}()
 
-	j, err := newJobRunner(config.APIAddr, "", config.SiaDirectory)
+	j, err := newJobRunner(config.APIAddr, config.APIPassword, config.SiaDirectory)
 	if err != nil {
 		return nil, err
 	}

--- a/ant/jobrunner_test.go
+++ b/ant/jobrunner_test.go
@@ -12,7 +12,7 @@ func TestNewJobRunner(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(datadir)
-	siad, err := newSiad("siad", datadir, "localhost:31337", "localhost:31338", "localhost:31339")
+	siad, err := newSiad("siad", datadir, "localhost:31337", "localhost:31338", "localhost:31339", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ant/siad.go
+++ b/ant/siad.go
@@ -22,7 +22,7 @@ import (
 // exec.Command.  An error is returned if starting siad fails, otherwise a
 // pointer to siad's os.Cmd object is returned.  The data directory `datadir`
 // is passed as siad's `--sia-directory`.
-func newSiad(siadPath string, datadir string, apiAddr string, rpcAddr string, hostAddr string) (*exec.Cmd, error) {
+func newSiad(siadPath string, datadir string, apiAddr string, rpcAddr string, hostAddr string, apiPassword string) (*exec.Cmd, error) {
 	if err := checkSiadConstants(siadPath); err != nil {
 		return nil, err
 	}
@@ -31,9 +31,16 @@ func newSiad(siadPath string, datadir string, apiAddr string, rpcAddr string, ho
 	if err != nil {
 		return nil, err
 	}
-	cmd := exec.Command(siadPath, "--modules=cgthmrw", "--authenticate-api=false", "--no-bootstrap", "--sia-directory="+datadir, "--api-addr="+apiAddr, "--rpc-addr="+rpcAddr, "--host-addr="+hostAddr)
+	args := []string{"--modules=cgthmrw", "--no-bootstrap", "--sia-directory="+datadir, "--api-addr="+apiAddr, "--rpc-addr="+rpcAddr, "--host-addr="+hostAddr}
+	if apiPassword == "" {
+		args = append(args, "--authenticate-api=false")
+	}
+	cmd := exec.Command(siadPath, args...)
 	cmd.Stderr = logfile
 	cmd.Stdout = logfile
+	if apiPassword != "" {
+		cmd.Env = append(os.Environ(), "SIA_API_PASSWORD="+apiPassword)
+	}
 
 	if err := cmd.Start(); err != nil {
 		return nil, err

--- a/ant/siad_test.go
+++ b/ant/siad_test.go
@@ -20,7 +20,7 @@ func TestNewSiad(t *testing.T) {
 	}
 	defer os.RemoveAll(datadir)
 
-	siad, err := newSiad("siad", datadir, "localhost:9990", "localhost:0", "localhost:0")
+	siad, err := newSiad("siad", datadir, "localhost:9990", "localhost:0", "localhost:0", "")
 	if err != nil {
 		t.Error(err)
 		return
@@ -34,7 +34,7 @@ func TestNewSiad(t *testing.T) {
 	siad.Process.Kill()
 
 	// verify that NewSiad returns an error given invalid args
-	_, err = newSiad("siad", datadir, "this_is_an_invalid_addres:1000000", "localhost:0", "localhost:0")
+	_, err = newSiad("siad", datadir, "this_is_an_invalid_addres:1000000", "localhost:0", "localhost:0", "")
 	if err == nil {
 		t.Fatal("expected newsiad to return an error with invalid args")
 	}

--- a/sia-antfarm/ant.go
+++ b/sia-antfarm/ant.go
@@ -38,6 +38,7 @@ func connectAnts(ants ...*ant.Ant) error {
 	}
 	targetAnt := ants[0]
 	c := client.New(targetAnt.APIAddr)
+	c.Password = targetAnt.Config.APIPassword
 	for _, ant := range ants[1:] {
 		connectQuery := ant.RPCAddr
 		addr := modules.NetAddress(ant.RPCAddr)


### PR DESCRIPTION
If the API password is not explicitly set, then it will be disabled for
that ant in order to avoid complications where the daemon tries to set a
password on the fly.